### PR TITLE
Landing page hero header not diplaying correctly

### DIFF
--- a/src/components/Client/LandingHero/LandingHero.css
+++ b/src/components/Client/LandingHero/LandingHero.css
@@ -21,7 +21,7 @@
 }
 
 .hero-input {
-    border-radius: 35px;
+    border-radius: 7px;
     border: none;
     padding: 10px;
     font-family: inherit;
@@ -37,11 +37,11 @@
     margin: 0 auto;
  }
 
- .search-container i {
+ .lh-search-container i {
     position: absolute;
 }
 
-.search-container {
+.lh-search-container {
     width: 100%;
     display: flex;
     padding: 0;
@@ -59,7 +59,7 @@
 #hero-search-button {
     padding: 12px;
     font-size: .85rem;
-    border-radius: 35px;
+    border-radius: 7px;
 }
 
 /* Desktop Layout */
@@ -67,25 +67,24 @@
     .landingHero-container {
         width: 100%;
         height: 500px;
+        justify-content: center;
     }
 
     .hero-heading {
         font-size: 4rem;
     }
 
-    .hero-input {
-        padding: 25px;
-        font-size: 2rem;
-    }
-
     .search-form {
-       width: 75%;
+       width: 900px;
     }
 
-    .search-container {
+    .lh-search-container {
         margin-bottom: 10px;
         display: flex;
         gap: 20px;
+        width: 100%;
+        justify-content: start;
+        align-items: start;
     }
 
     .icon {
@@ -94,9 +93,15 @@
         font-size: 2rem;
     }
 
-    #hero-search-button {
+    .hero-input {
         padding: 25px;
+        font-size: 1rem;
+        text-align: start;
+    }
+
+    #hero-search-button {
         font-size: 2rem;
+        padding: 13px 25px;
     }
 
 }

--- a/src/components/Client/LandingHero/LandingHero.js
+++ b/src/components/Client/LandingHero/LandingHero.js
@@ -36,7 +36,7 @@ const LandingHero = (props) => {
         <div aria-label="landing page hero" className="landingHero-container">
             <h3 className="hero-heading">Find your favourite</h3>
             <form className="search-form" id="hero-search">
-                <div className="search-container">
+                <div className="lh-search-container">
                     <i className="fa fa-search icon"></i>
                     <input 
                     type="search" 

--- a/src/components/Client/Search/Search.css
+++ b/src/components/Client/Search/Search.css
@@ -6,6 +6,10 @@
     background-color: var(--col-primary);
 }
 
+.search-container i {
+    position: absolute;
+}
+
 .searchOptions-container {
     display: flex;
     justify-content: space-between;


### PR DESCRIPTION
When viewing the landing page in desktop mode some items of the hero component are not displaying in the correct places.

The header is aligned right up against the top of it's container and the search icon and go buttons appear below the search field rather than along side it