### PR TITLE
Update email validation in Sign Up form

### DIFF
--- a/src/components/Client/SignupForm/SignupForm.js
+++ b/src/components/Client/SignupForm/SignupForm.js
@@ -38,11 +38,16 @@ const SignupForm = () => {
             return false
         }
 
-        if(email.length < 16) {
-            setEmailError('You must supply an email of at least 16 characters')
+        if(email.length < 3) {
+            setEmailError('You must supply an email of at least 3 characters')
             setFormOk(false)
             return false
         } 
+
+        if(email.includes("@")) {
+            setEmailError('The supplied email address must be in the correct format.')
+            setFormOk(false)
+        }
 
         if(forename === undefined || forename === '') { 
             setForenameError('You must supply a forename to register')


### PR DESCRIPTION
Currently the validation requires an email address to be 16 characters or greater which is incorrect. The minium length is 3 characters.