### PR TITLE
Navigation list appears too close to page scroll bar

### DIFF
--- a/src/components/Client/Header/header.css
+++ b/src/components/Client/Header/header.css
@@ -42,6 +42,7 @@
   display: none;
   padding: 0;
   left: -100%;
+  padding-right: 30px;
 }
 
 .nav-list {


### PR DESCRIPTION
As the title suggests the spaciong on the right hand side of the navigation bar is set too small ( or not set ) and appears way too close to the edge of the page.